### PR TITLE
Small README change

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It contains _no payloads_. You must download and place the payloads in the "payl
 1. Install [Homebrew](https://brew.sh)
 2. Install Python 3: `brew install python`
 3. Install libusb: `brew install libusb`
-4. Install Python dependencies: `python3 -m pip install -r requirements.txt`
+4. Install Python dependencies: `python3 -m pip install pyusb`
 
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-pyusb==1.0.2
-tkinter


### PR DESCRIPTION
   Tkinter comes with Py3 by default, and there is no reason for the requirements.txt to exist for one module. A pretty minimal change overall.